### PR TITLE
finished tree logo design and refactor deleting components logic

### DIFF
--- a/src/actions/components.js
+++ b/src/actions/components.js
@@ -76,7 +76,8 @@ export const addComponent = ({ title }) => (dispatch) => {
   dispatch({ type: SET_SELECTABLE_PARENTS });
 };
 
-export const deleteComponent = ({ index, id, parent }) => (dispatch) => {
+export const deleteComponent = ({ index, id, parent, routes }) => (dispatch) => {
+  console.log('routes: ', routes);
   // Delete Component  from its parent if it has a parent.
   if (parent && parent.id) {
     dispatch(deleteChild({ parent, childId: id, childIndex: index }));
@@ -85,6 +86,12 @@ export const deleteComponent = ({ index, id, parent }) => (dispatch) => {
   dispatch(parentReassignment({ index, id, parent }));
   dispatch({ type: DELETE_COMPONENT, payload: { index, id } });
   dispatch({ type: SET_SELECTABLE_PARENTS });
+  // Delete the Component from its parent's routelist
+  if (parent) dispatch(deleteRoute({ routerCompId: parent.id, routeCompId: id }));
+  // Set it's Route Children to non routes, ieroute stats to false and visibility to true
+  routes.forEach(({ routeCompId }) => {
+    dispatch(deleteRoute({ routerCompId: id, routeCompId }));
+  });
 };
 
 export const updateComponent = ({

--- a/src/components/LeftColExpansionPanel.jsx
+++ b/src/components/LeftColExpansionPanel.jsx
@@ -217,6 +217,7 @@ const LeftColExpansionPanel = (props) => {
                 index,
                 id,
                 parent,
+                routes,
               });
             }}
             aria-label="Delete"

--- a/src/components/SortableComponent.jsx
+++ b/src/components/SortableComponent.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import SortableTree from 'react-sortable-tree';
 import PropTypes from 'prop-types';
 import 'react-sortable-tree/style.css';
+import IconButton from '@material-ui/core/IconButton';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import InfoIcon from '@material-ui/icons/InfoOutlined';
 
 const SortableComponent = (props) => {
   const {
@@ -19,38 +22,33 @@ const SortableComponent = (props) => {
   };
 
   const nodeClicked = (rowInfo) => {
-    console.log('rowInfo: ', rowInfo);
-    if (rowInfo.node.visible) onExpansionPanelChange(rowInfo.node);
+    onExpansionPanelChange(rowInfo.node);
   };
 
   const generateNodeProps = (rowInfo) => {
     const rowProps = {
-      onClick: () => nodeClicked(rowInfo),
-      style: {
-        color: 'red',
-      },
       buttons: [
-         <button key='1'
+         <InfoIcon key={rowInfo.node.id}
+         className='row_color'
+         onClick={() => nodeClicked(rowInfo)}
          style={{
            verticalAlign: 'middle',
-           backgroundColor: rowInfo.node.color,
+           color: rowInfo.node.color,
          }}
      >
-         {' '}
-     </button>,
+     </InfoIcon>,
       ],
     };
-    console.log('rowInfo.node.color: ', rowInfo.node.color);
     if (rowInfo.node.route) {
       rowProps.buttons.push(
-        <button key='1'
+        <VisibilityIcon key='1'
             style={{
               verticalAlign: 'middle',
+              color: rowInfo.node.color,
             }}
             onClick={() => toggleViewBtn(rowInfo)}
         >
-            VIEW
-        </button>
+        </VisibilityIcon>,
       );
     }
     return rowProps;

--- a/src/containers/LeftContainer.jsx
+++ b/src/containers/LeftContainer.jsx
@@ -21,8 +21,10 @@ const mapDispatchToProps = dispatch => ({
       id, index, parent, newParentId, color, stateful, router,
     })),
   deleteComponent: ({
-    index, id, parent,
-  }) => dispatch(actions.deleteComponent({ index, id, parent })),
+    index, id, parent, routes,
+  }) => dispatch(actions.deleteComponent({
+    index, id, parent, routes,
+  })),
   moveToBottom: componentId => dispatch(actions.moveToBottom(componentId)),
   moveToTop: componentId => dispatch(actions.moveToTop(componentId)),
   openExpansionPanel: component => dispatch(actions.openExpansionPanel(component)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Tree logo visualization and delete component logic
## Description

<!--- Describe your changes in detail -->
Tree logo visualization: 
1. Added an info logo that when clicked on selects the component on the kova stage and on the left container.  Moved the select onclick from the entire tree node to the info logo itself

2. Added view logo to toggle routes components on and off on the kova stage

3. Both logos are color coordinated to the component box color

Delete component logic:
1. When deleting a component, makes all of its route children visible and turn their route boolean to false

2. When deleting a component, delete it from the route list from its parent

<!--- Why is this change required? What problem does it solve? -->
1. The logos and color coordination provide a better visual 
2. Moving the onclick handler from the tree node to the info logo avoids double click handling when clicking the view logo
3. The component logic cleans up the deleted component from it's parent's route list and resets its children to non-routed components

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- Visual tests on the app itself

<!--- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
