### PR TITLE
 refactor route and children visibility toggle

### DIFF
--- a/src/actions/components.js
+++ b/src/actions/components.js
@@ -244,3 +244,5 @@ export const setVisible = compId => ({
   type: SET_VISIBLE,
   payload: compId,
 });
+
+export const setSelectableParents = () => ({ type: SET_SELECTABLE_PARENTS });

--- a/src/components/LeftColExpansionPanel.jsx
+++ b/src/components/LeftColExpansionPanel.jsx
@@ -76,7 +76,6 @@ const LeftColExpansionPanel = (props) => {
     moveToTop,
     addRoute,
     deleteRoute,
-    setSelectableParents,
   } = props;
   const {
     title,

--- a/src/components/LeftColExpansionPanel.jsx
+++ b/src/components/LeftColExpansionPanel.jsx
@@ -76,6 +76,7 @@ const LeftColExpansionPanel = (props) => {
     moveToTop,
     addRoute,
     deleteRoute,
+    setSelectableParents,
   } = props;
   const {
     title,

--- a/src/components/RightTabs.jsx
+++ b/src/components/RightTabs.jsx
@@ -79,6 +79,7 @@ class RightTabs extends Component {
       rightColumnOpen,
       setVisible,
       onExpansionPanelChange,
+      setSelectableParents,
     } = this.props;
     const { value } = this.state;
 
@@ -112,6 +113,7 @@ class RightTabs extends Component {
         {value === 0 && <SortableComponent
           components={components}
           setVisible={setVisible}
+          setSelectableParents={setSelectableParents}
           onExpansionPanelChange={onExpansionPanelChange}
         />}
         {value === 1 && <Props
@@ -135,6 +137,7 @@ RightTabs.propTypes = {
   rightColumnOpen: PropTypes.bool.isRequired,
   setVisible: PropTypes.func.isRequired,
   onExpansionPanelChange: PropTypes.func,
+  setSelectableParents: PropTypes.func,
 };
 
 export default withStyles(styles)(RightTabs);

--- a/src/components/SortableComponent.jsx
+++ b/src/components/SortableComponent.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import 'react-sortable-tree/style.css';
 import IconButton from '@material-ui/core/IconButton';
 import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
 
 const SortableComponent = (props) => {
@@ -11,6 +12,7 @@ const SortableComponent = (props) => {
     components,
     setVisible,
     onExpansionPanelChange,
+    setSelectableParents,
   } = props;
 
   const rootComponents = components.filter(
@@ -19,6 +21,7 @@ const SortableComponent = (props) => {
 
   const toggleViewBtn = (rowInfo) => {
     setVisible(rowInfo.node.id);
+    setSelectableParents();
   };
 
   const nodeClicked = (rowInfo) => {
@@ -32,7 +35,6 @@ const SortableComponent = (props) => {
          className='row_color'
          onClick={() => nodeClicked(rowInfo)}
          style={{
-           verticalAlign: 'middle',
            color: rowInfo.node.color,
          }}
      >
@@ -41,14 +43,19 @@ const SortableComponent = (props) => {
     };
     if (rowInfo.node.route) {
       rowProps.buttons.push(
-        <VisibilityIcon key='1'
+        rowInfo.node.visible ? (<VisibilityIcon key='1'
             style={{
-              verticalAlign: 'middle',
               color: rowInfo.node.color,
             }}
             onClick={() => toggleViewBtn(rowInfo)}
         >
-        </VisibilityIcon>,
+        </VisibilityIcon>) : (<VisibilityOff key='1'
+            style={{
+              color: rowInfo.node.color,
+            }}
+            onClick={() => toggleViewBtn(rowInfo)}
+        >
+        </VisibilityOff>),
       );
     }
     return rowProps;

--- a/src/containers/RightContainer.jsx
+++ b/src/containers/RightContainer.jsx
@@ -7,6 +7,7 @@ import {
   addCompProp,
   setVisible,
   openExpansionPanel,
+  setSelectableParents,
 } from '../actions/components';
 import Snackbars from '../components/Snackbars.jsx';
 import RightTabs from '../components/RightTabs.jsx';
@@ -19,6 +20,7 @@ const mapDispatchToProps = dispatch => ({
   addProp: prop => dispatch(addCompProp(prop)),
   setVisible: compId => dispatch(setVisible(compId)),
   openExpansionPanel: component => dispatch(openExpansionPanel(component)),
+  setSelectableParents: () => dispatch(setSelectableParents()),
 });
 
 const mapStateToProps = store => ({
@@ -54,6 +56,7 @@ class RightContainer extends Component {
       addProp,
       rightColumnOpen,
       setVisible,
+      setSelectableParents,
     } = this.props;
 
     return (
@@ -66,6 +69,7 @@ class RightContainer extends Component {
           rightColumnOpen={rightColumnOpen}
           setVisible={setVisible}
           onExpansionPanelChange={this.handleExpansionPanelChange}
+          setSelectableParents={setSelectableParents}
         />
         <Snackbars
           successOpen={successOpen}

--- a/src/utils/componentReducer.util.js
+++ b/src/utils/componentReducer.util.js
@@ -230,7 +230,10 @@ export const deleteRoute = (state, { routerCompId, routeCompId }) => ({
       comp.routes = routes;
       return { ...comp };
     }
-    if (comp.id === routeCompId) return { ...comp, route: false, visible: true };
+    if (comp.id === routeCompId) {
+      if (!comp.visible) setVisible(state, comp.id);
+      return { ...comp, route: false };
+    }
     return comp;
   }),
 });

--- a/src/utils/componentReducer.util.js
+++ b/src/utils/componentReducer.util.js
@@ -212,7 +212,7 @@ export const addRoute = (state, {
       comp.routes = [...comp.routes, newRoute];
       return { ...comp };
     }
-    if (comp.id === routeCompId) return { ...comp, route: true, visible: false };
+    if (comp.id === routeCompId) return { ...comp, route: true };
     return comp;
   }),
 });

--- a/src/utils/setSelectableParents.util.js
+++ b/src/utils/setSelectableParents.util.js
@@ -12,8 +12,12 @@ const getAllChildren = (components, childrenIds, unSelectable = []) => {
 
 const getSelectableParents = ({ id, childrenIds, components }) => {
   const unSelectableParents = getAllChildren(components, childrenIds, [id]);
-  return components
+  const selectableParentsArr = components
     .filter(comp => !unSelectableParents.includes(comp.id) && comp.visible);
+  return selectableParentsArr.map(({ id, title }) => ({
+    id,
+    title,
+  }));
 };
 
 const setSelectableParents = components => components.map(

--- a/src/utils/setSelectableParents.util.js
+++ b/src/utils/setSelectableParents.util.js
@@ -13,7 +13,7 @@ const getAllChildren = (components, childrenIds, unSelectable = []) => {
 const getSelectableParents = ({ id, childrenIds, components }) => {
   const unSelectableParents = getAllChildren(components, childrenIds, [id]);
   return components
-    .filter(comp => !unSelectableParents.includes(comp.id));
+    .filter(comp => !unSelectableParents.includes(comp.id) && comp.visible);
 };
 
 const setSelectableParents = components => components.map(


### PR DESCRIPTION
Children will now always follow the visibility of its parents

added on and off eyeball icon